### PR TITLE
Fix/s3 generate image url

### DIFF
--- a/app/server/api/images/index.get.ts
+++ b/app/server/api/images/index.get.ts
@@ -37,8 +37,8 @@ export default defineEventHandler(async (event): Promise<PaginatedResponse> => {
     
     // 日時の降順でソート
     imageFiles.sort((a, b) => {
-      const dateA = a.LastModified ? new Date(a.LastModified).getTime() : 0;
-      const dateB = b.LastModified ? new Date(b.LastModified).getTime() : 0;
+      const dateA = new Date(a.LastModified || 0).getTime();
+      const dateB = new Date(b.LastModified || 0).getTime();
       return dateB - dateA; // 降順
     });
     

--- a/app/server/utils/s3.ts
+++ b/app/server/utils/s3.ts
@@ -113,8 +113,8 @@ export const generateImageUrl = (key: string, config: MinioConfig): string => {
   
   // キーの先頭のスラッシュを処理
   const processedKey = key.startsWith('/') ? key.substring(1) : key;
-  
-  return `${baseUrl}${config.bucket}/${processedKey}`;
+  // 本番環境では、baseUrlにバケット名が含まれているので、そのまま返す（minIOとS3の違い）
+  return process.env.NODE_ENV === 'production' ?  `${baseUrl}${processedKey}` : `${baseUrl}${config.bucket}/${processedKey}`;
 };
 
 /**


### PR DESCRIPTION
本番環境では、baseUrlにバケット名が含まれているので、そのまま返す（minIOとS3の違い）