### PR TITLE
GitHub Actionsにリントチェックワークフローを追加

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,31 @@
+name: Lint Check
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened]
+    paths:
+      - 'app/**'
+  workflow_dispatch:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+          cache-dependency-path: './app/package-lock.json'
+
+      - name: Install dependencies
+        run: npm ci
+        working-directory: ./app
+
+      - name: Run ESLint
+        run: npm run lint
+        working-directory: ./app


### PR DESCRIPTION
- リントチェックのためのGitHub Actionsワークフローを新規作成
- Node.js v22を使用
- appディレクトリ内でnpm ciとeslintを実行
- プルリクエスト時とワークフロー手動実行に対応