### PR TITLE
Markdownプレビューコンポーネントにiframe用のスタイルを追加

### DIFF
--- a/app/components/MarkdownPreview.vue
+++ b/app/components/MarkdownPreview.vue
@@ -93,4 +93,10 @@ useHead({
   border: none;                                /* 内側の余計な枠線は不要 */
   line-height: 1.45;                           /* 読みやすい行間 */
 }
+.markdown-preview iframe {
+  width: 100%;
+  max-width: 560px; /* 最大幅はYoutubeで貼り付けコピー取得時の幅 */
+  aspect-ratio: 16 / 9;
+  border: none;
+}
 </style>

--- a/app/components/MarkdownPreview.vue
+++ b/app/components/MarkdownPreview.vue
@@ -95,7 +95,7 @@ useHead({
 }
 .markdown-preview iframe {
   width: 100%;
-  max-width: 560px; /* 最大幅はYoutubeで貼り付けコピー取得時の幅 */
+  max-width: 560px; /* デフォルトの埋め込み幅を再現しつつ、レスポンシブ対応 */
   aspect-ratio: 16 / 9;
   border: none;
 }


### PR DESCRIPTION
- iframeの幅を100%に設定
- 最大幅を560pxに制限
- 16:9のアスペクト比を適用
- 枠線を削除